### PR TITLE
fix: strong-named assembly required when running W2TConsole

### DIFF
--- a/Sources/TFS.SyncService.W2TConsole/TFS.SyncService.W2TConsole.csproj
+++ b/Sources/TFS.SyncService.W2TConsole/TFS.SyncService.W2TConsole.csproj
@@ -31,6 +31,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -74,9 +76,18 @@
   <PropertyGroup>
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignManifests>false</SignManifests>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
+    <Reference Include="ManyConsole, Version=1.0.0.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ManyConsole.1.0.0.4\lib\ManyConsole.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Options, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Options.5.3.0\lib\net4-client\Mono.Options.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -120,10 +131,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ManyConsole\ManyConsole.csproj">
-      <Project>{90db8534-c471-47cf-999d-be7a86070979}</Project>
-      <Name>ManyConsole</Name>
-    </ProjectReference>
     <ProjectReference Include="..\TFS.SyncService.Adapter.TFS2010\TFS.SyncService.Adapter.TFS2012.csproj">
       <Project>{40acca31-f82b-42d7-8e7a-b34c0aca5a9b}</Project>
       <Name>TFS.SyncService.Adapter.TFS2012</Name>
@@ -202,5 +209,12 @@
   -->
   <!-- Override Publish target -> this fixes build errors because console app is not distributed as clickonce app -->
   <Target Name="Publish">
+  </Target>
+  <Import Project="..\packages\StrongNamer.0.2.5\build\StrongNamer.targets" Condition="Exists('..\packages\StrongNamer.0.2.5\build\StrongNamer.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StrongNamer.0.2.5\build\StrongNamer.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StrongNamer.0.2.5\build\StrongNamer.targets'))" />
   </Target>
 </Project>

--- a/Sources/TFS.SyncService.W2TConsole/packages.config
+++ b/Sources/TFS.SyncService.W2TConsole/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ManyConsole" version="1.0.0.4" targetFramework="net452" />
   <package id="Microsoft.DependencyValidation.Analyzers" version="0.11.0" targetFramework="net452" />
-  <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
+  <package id="Mono.Options" version="5.3.0" targetFramework="net452" />
+  <package id="StrongNamer" version="0.2.5" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Update ManyConsole to remove the deprecated NDeskOption dependency
- Add StrongNamer to automatically sign all dependencies when building the project (ManyConsole from Nuget is not singed)